### PR TITLE
QRコードを作成して画面に描画

### DIFF
--- a/den.rb
+++ b/den.rb
@@ -29,7 +29,8 @@ Font_size = case Input_font_size
                 when "3" then 360
                 else 240
             end
-
+print "現在繋いでいるWi-FiのSSIDを入力してください："
+Input_ssid = gets.chomp
 
 # Contentクラスを定義
 
@@ -118,7 +119,6 @@ class Qr_make
         @my_URL = "http://#{my_address}:8000/"
         puts "URL: #{@my_URL}"
         @font = Gosu::Font.new(50, name: "fonts/NotoSansJP-Regular.ttf")
-
         # QRコード作成
         qrcode = RQRCode::QRCode.new(@my_URL)
 
@@ -165,7 +165,7 @@ class Qr_make
     end
 
     def draw
-        @font.draw_text("Wi-Fiを○○に繋いで\nQRコードを読み取ってください", 0, 500, 2, 1.0, 1.0, Gosu::Color::WHITE)
+        @font.draw_text("Wi-Fiを#{Input_ssid}に繋いで\nQRコードを読み取ってください", 0, 500, 2, 1.0, 1.0, Gosu::Color::WHITE)
         @qr_image.draw(@x_qr, @y_qr, 2)
     end
 end

--- a/den.rb
+++ b/den.rb
@@ -35,7 +35,7 @@ class Content
     include Singleton
 
     attr_accessor :input_text, :input_color, :input_color_code, :input_font_size, :input_count, :font_size, :font1, :font2, :ip_index, :ip_message
-    attr_reader :input_length, :font_ratio, :font_y_offset, :x, :y, :speed, :my_ip, :my_ip_address, :ip_index, :ip_message
+    attr_reader :input_length, :font_ratio, :font_y_offset, :x, :y, :speed, :my_ip, :my_URL, :ip_index, :ip_message
     
     def initialize
         @font_ratio = Font_size * 0.68
@@ -53,8 +53,8 @@ class Content
         @y = 300
         @speed = -2
         @my_ip = my_address.chomp
-        @my_ip_address = "http://#{my_address}:8000/"
-        puts "URL: #{@my_ip_address}"
+        @my_URL = "http://#{my_address}:8000/"
+        puts "URL: #{@my_URL}"
     end
 
 

--- a/den.rb
+++ b/den.rb
@@ -117,6 +117,8 @@ class Qr_make
         @my_ip = my_address.chomp
         @my_URL = "http://#{my_address}:8000/"
         puts "URL: #{@my_URL}"
+        @font = Gosu::Font.new(50, name: "fonts/NotoSansJP-Regular.ttf")
+
         # QRコード作成
         qrcode = RQRCode::QRCode.new(@my_URL)
 
@@ -163,6 +165,7 @@ class Qr_make
     end
 
     def draw
+        @font.draw_text("Wi-Fiを○○に繋いで\nQRコードを読み取ってください", 0, 500, 2, 1.0, 1.0, Gosu::Color::WHITE)
         @qr_image.draw(@x_qr, @y_qr, 2)
     end
 end


### PR DESCRIPTION
■ 実装したこと
- IPアドレスを取得してURLを作成
- QRコードのイメージを作成
- QRコードを画像として作成
- QRコードを描画
- Wi-Fiを標準入力で受け取って案内文を描画